### PR TITLE
Package-Control for Sublime Text now supports Nit syntax highlighting. 

### DIFF
--- a/pages/sublime-text.mdwn
+++ b/pages/sublime-text.mdwn
@@ -6,11 +6,9 @@ As of now, the bundle for supporting Nit in Sublime-Text only supports syntax hi
 
 ## How to install
 
-To install the support for Nit in Sublime-Text, you can just copy the syntax highlighter property list file (available [here](https://raw.githubusercontent.com/R4PaSs/Sublime-Nit/master/Nit.tmLanguage), and copy it in your Packages folder (~/.config/sublime-text-version/Packages/).
+To install the support for Nit in Sublime-Text, you can either use [Pacakge-Control](https://sublime.wbond.net/) and look for [NitSyntaxHighlighter](https://github.com/itsWill/NitSyntaxHighlighter) or  you can just copy the syntax highlighter property list file (available [here](https://raw.githubusercontent.com/R4PaSs/Sublime-Nit/master/Nit.tmLanguage), and copy it in your Packages folder (~/.config/sublime-text-version/Packages/).
 
 When you are done with this step, you can enjoy Nit source highlighting on any .nit source file automatically !
-
-Alternatively, when supported, you'll be able to install the support for Nit via [Package-Control](https://sublime.wbond.net/) !
 
 ## Contributing
 


### PR DESCRIPTION
I submitted the [NitSyntaxHighlighter](https://github.com/itsWill/NitSyntaxHighlighter) to the package control project for sublime text. It has recently been approved and can now be installed through package control. I've changed the documentation accordingly. 

Many thanks to @R4PaSs  since the work is his, I just submitted the highlighter.
