### PR TITLE
gitignore cleanup for language manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,6 @@
 /tmp/
 doc.zip
 man.zip
+catalog.zip
 
-pages/manual/blank
-pages/manual/nitreference-main.md
-pages/manual/nitreference-main.tex
-pages/manual/nitreference.aux
-pages/manual/nitreference.epub
-pages/manual/nitreference.log
-pages/manual/nitreference.pdf
+pages/manual/*


### PR DESCRIPTION
Adds the catalog.zip and all pages in the manual that are pulled during deployment. index.md is already commited so will continue to update.